### PR TITLE
Update employees.rb

### DIFF
--- a/lib/wotc/client/employees.rb
+++ b/lib/wotc/client/employees.rb
@@ -24,7 +24,7 @@ module WOTC
 
       # Get employee's WOTC status
       def employee_wotc_status(employee_id)
-        get("employees#{employee_id}/wotc/status")
+        get("employees/#{employee_id}/wotc/status")
       end
 
       # Get wotc info for specific employee

--- a/lib/wotc/version.rb
+++ b/lib/wotc/version.rb
@@ -1,3 +1,3 @@
 module WOTC
-  VERSION = '0.1.10'
+  VERSION = '0.1.11'
 end


### PR DESCRIPTION
Add missing '/'. (Sry lazy to add tests and fixtures)

```
3.0.4 :004 > result = we.wotc_company.client.employee_wotc_status(we.resource_id).body.with_indifferent_access
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
/var/www/workstream-backend-staging/shared/bundle/ruby/3.0.0/gems/wotc-0.1.10/lib/faraday/raise_http_exception.rb:17:in `block in call':       URL: https://sandbox.wotc.com/portal/api/v1/employees17793/wotc/status (WOTC::NotFound)
      method: get
      response status: 404
      response body: {"message"=>"The route api/v1/employees17793/wotc/status could not be found."}
```