### PR TITLE
chore: utilize the page variable in the endpoint instead of hardcoded

### DIFF
--- a/lib/wotc/request.rb
+++ b/lib/wotc/request.rb
@@ -30,8 +30,8 @@ module WOTC
     # return just one page when auto_paginate is set false.
     def paginate(path, options={})
       per_page = options[:per_page] || options["per_page"] || @per_page
-      page = options[:page] || options["page"]
-      response = get(path+"?page=1&per_page=#{per_page}")
+      page = options[:page] || options["page"] || 1
+      response = get(path+"?page=#{page}&per_page=#{per_page}")
 
       # return one page results without pagination.
       return response if !@auto_paginate

--- a/lib/wotc/version.rb
+++ b/lib/wotc/version.rb
@@ -1,3 +1,3 @@
 module WOTC
-  VERSION = '0.1.11'
+  VERSION = '0.1.12'
 end


### PR DESCRIPTION
**Context**

WOTC has made some changes in the API lately as a result, it has caused a lot of WOTC employee to not have its `resource_id`. Hence, we are intending to have a rake task prepared to look up on existing applicants and link it back to our WOTC::Employee's `resource_id`. In which, we will manually toggle the `auto_paginate` off for more control. In which, we have noticed that the page option is not been taken into consideration in the request url. Therefore, this change will make the correction to consider the option

This shouldn't change anything given that currently, there isn't any BE usage of this paginate given that the default `auto_paginate` is `true`
