### PR TITLE
fix: standardize error handling to always use Faraday::Response

### DIFF
--- a/lib/faraday/raise_http_exception.rb
+++ b/lib/faraday/raise_http_exception.rb
@@ -7,7 +7,8 @@ module FaradayMiddleWare
     end
 
     def call(env)
-      @app.call(env).on_complete do |response|
+      response = @app.call(env)
+      response.on_complete do |_env|
         case response.status.to_i
         when 400
           raise WOTC::BadRequest.new(response)

--- a/lib/wotc/error.rb
+++ b/lib/wotc/error.rb
@@ -4,21 +4,25 @@ module WOTC
     attr_reader :http_method, :url, :errors
 
     def initialize(response)
-      super
       @response = response.dup
-      @http_method = response.env.method.to_s
-      @url = response.env.url
-      if response.body.is_a?(Hash) && !response.body.empty? && !response.body.fetch("errors", nil).nil?
-        @raw_errors = response.body.fetch("errors")
+      env = response.env
+      # Use hash-style access for :method to avoid calling Kernel#method
+      @http_method = env[:method].to_s.upcase.presence || "UNKNOWN"
+      @url = env.url.to_s
+      @status = response.status
+      @body = response.body
+      if @body.is_a?(Hash) && !@body.empty? && !@body.fetch("errors", nil).nil?
+        @raw_errors = @body.fetch("errors")
       end
+      super()
     end
 
     def message
       <<-HEREDOC
       URL: #{@url}
       method: #{@http_method}
-      response status: #{@response.status}
-      response body: #{@response.body}
+      response status: #{@status}
+      response body: #{@body}
       HEREDOC
     end
 

--- a/lib/wotc/version.rb
+++ b/lib/wotc/version.rb
@@ -1,3 +1,3 @@
 module WOTC
-  VERSION = '0.1.13'
+  VERSION = '0.1.14'
 end


### PR DESCRIPTION
## Background

v0.1.13 fixed the `Kernel#method` conflict in `WOTC::Error` by using `response.env.method` instead of `response.method`. However, the `raise_http_exception` middleware's `on_complete` callback yields a `Faraday::Env` (not a `Faraday::Response`), so `response.env` raised `NoMethodError: undefined method 'env' for Faraday::Env` in production (Sentry).

This PR fixes the root cause: the middleware now captures and passes the actual `Faraday::Response` so `WOTC::Error` always receives a consistent type. `error.rb` is simplified to only handle `Faraday::Response`.

## Work items

```diff
~ Updated raise_http_exception.rb to pass Faraday::Response instead of Faraday::Env
~ Simplified error.rb to only handle Faraday::Response (removed dual-type branching)
~ Used env[:method] (hash-style access) to avoid Kernel#method conflict
~ Bumped version to 0.1.14
```

## Details

### The bug (v0.1.13)

`WOTC::Error` receives different types depending on the code path:

| Caller | Previously passed |
|---|---|
| `raise_http_exception.rb` (middleware) | `Faraday::Env` (from `on_complete` callback) |
| `registers.rb`, client modules | `Faraday::Response` |

v0.1.13's `response.env.method` worked for `Faraday::Response` but crashed on `Faraday::Env`.

### The fix

Normalize at the source: `raise_http_exception.rb` now captures the `Faraday::Response` returned by `@app.call(env)` and passes that to the error class. `error.rb` is simplified to always expect `Faraday::Response`.

Made with [Cursor](https://cursor.com)